### PR TITLE
fix: resolve authentication race condition in room initialization

### DIFF
--- a/apps/client/src/app/pages/room/room.component.ts
+++ b/apps/client/src/app/pages/room/room.component.ts
@@ -754,6 +754,19 @@ export class RoomComponent implements OnInit, OnDestroy {
         @Inject(PLATFORM_ID) private platformId: Object
     ) {
         effect(() => {
+            const status = this.socket.status();
+            const currentFragment = this.route.snapshot.fragment;
+
+            if (status === 'connected' && currentFragment) {
+                this.router.navigate([], {
+                    relativeTo: this.route,
+                    fragment: undefined,
+                    replaceUrl: true 
+                });
+            }
+        });
+
+        effect(() => {
             if (!isPlatformBrowser(this.platformId)) return;
             const state = this.socket.roomState();
 
@@ -792,18 +805,8 @@ export class RoomComponent implements OnInit, OnDestroy {
                     }
 
                     if (this.socket.status() !== 'connected' || this.roomId() !== id) {
+                        this.socket.disconnect(false);
                         this.socket.connect(id, this.socket.getRoomKey());
-                        
-                        if (fragmentKey) {
-
-                            Promise.resolve().then(() => {
-                                this.router.navigate([], {
-                                    relativeTo: this.route,
-                                    fragment: undefined,
-                                    replaceUrl: true 
-                                });
-                            });
-                        }
                     }
                 }
             });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signing-room/source",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "AGPL-3.0",
   "author": {
     "name": "Sean Carlin",


### PR DESCRIPTION
Resolves a critical race condition introduced in v1.1.0 where the 
Coordinator role was intermittently failing to set upon room entry.

The issue occurred because the URL fragment (encryption key) was being 
scrubbed from the address bar before the WebSocket handshake and 
subsequent 'AUTH' message could be successfully processed by the server.

Key Fixes:
- Moved URL scrubbing logic into an Angular effect() within the 
  RoomComponent constructor to ensure strict execution order.
- The encryption key is now only removed from the browser history 
  AFTER the SocketService confirms a 'connected' state.
- Satisfies security audit requirements by eliminating the previous 
  500ms arbitrary delay while ensuring sensitive keys are scrubbed 
  as soon as technically feasible.

This fix ensures that the 'ROLE_UPDATE' message from the server is 
consistently received while the client still maintains full 
cryptographic context.

- updating version to v1.1.1 for release