### PR TITLE
Blind websocket metadata

### DIFF
--- a/apps/client/src/app/pages/create/create.component.ts
+++ b/apps/client/src/app/pages/create/create.component.ts
@@ -212,11 +212,15 @@ export class CreateComponent implements OnInit {
             const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(encryptedAdminToken));
             const adminHash = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
 
+            const defaultName = "Untitled Room";
+            const encryptedRoomName = await this.encryption.encrypt(defaultName, encryptionKey);
+
             const res: any = await firstValueFrom(this.socket['http'].post(`${environment.apiUrl}/api/room`, { 
                 encryptedPsbt: encryptedData, 
                 adminToken: adminHash,
                 network: this.selectedNetwork(),
-                protocolVersion: PROTOCOL_VERSION
+                protocolVersion: PROTOCOL_VERSION,
+                encryptedRoomName
             }));
 
             sessionStorage.setItem(`admin_token_${res.roomId}`, encryptedAdminToken);

--- a/apps/client/src/app/pages/create/create.component.ts
+++ b/apps/client/src/app/pages/create/create.component.ts
@@ -209,9 +209,12 @@ export class CreateComponent implements OnInit {
             const encryptedData = await this.encryption.encrypt(this.rawHex, encryptionKey);
             const encryptedAdminToken = await this.encryption.encrypt(adminSecret, encryptionKey);
             
+            const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(encryptedAdminToken));
+            const adminHash = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+
             const res: any = await firstValueFrom(this.socket['http'].post(`${environment.apiUrl}/api/room`, { 
                 encryptedPsbt: encryptedData, 
-                adminToken: encryptedAdminToken,
+                adminToken: adminHash,
                 network: this.selectedNetwork(),
                 protocolVersion: PROTOCOL_VERSION
             }));

--- a/apps/client/src/app/pages/room/room.component.ts
+++ b/apps/client/src/app/pages/room/room.component.ts
@@ -161,9 +161,9 @@ import * as QRCode from 'qrcode';
                     <div class="flex justify-between">
                         <label class="text-xs font-bold text-slate-500 uppercase tracking-wider">Room Name</label>
                         <span class="text-xs font-mono" 
-                            [class.text-red-400]="newRoomName().length > 32" 
-                            [class.text-slate-600]="newRoomName().length <= 32">
-                            {{ newRoomName().length }} / 32
+                            [class.text-red-400]="newRoomName().length > 64" 
+                            [class.text-slate-600]="newRoomName().length <= 64">
+                            {{ newRoomName().length }} / 64
                         </span>
                     </div>
                     
@@ -171,12 +171,12 @@ import * as QRCode from 'qrcode';
                         type="text" 
                         [(ngModel)]="newRoomName" 
                         (keyup.enter)="saveRoomName()"
-                        maxlength="32"  placeholder="e.g. Q1 Treasury Board Vote"
+                        maxlength="64"  placeholder="e.g. Q1 Treasury Board Vote"
                         class="w-full bg-slate-950 border border-slate-800 rounded-lg px-4 py-3 text-white placeholder:text-slate-600 focus:outline-none focus:border-emerald-500/50 transition"
                         autofocus
                     />
                     
-                    @if (newRoomName().length >= 32) {
+                    @if (newRoomName().length >= 64) {
                         <p class="text-xs text-red-400 animate-pulse">
                             Maximum length reached.
                         </p>
@@ -1146,7 +1146,7 @@ export class RoomComponent implements OnInit, OnDestroy {
 
     saveRoomName() {
         let name = this.newRoomName().trim();
-        const MAX_LENGTH = 32;
+        const MAX_LENGTH = 64;
 
         if (name.length > MAX_LENGTH) {
             name = name.slice(0, MAX_LENGTH);

--- a/apps/client/src/app/pages/room/room.component.ts
+++ b/apps/client/src/app/pages/room/room.component.ts
@@ -3,7 +3,7 @@
  * Licensed under the GNU Affero General Public License v3.0
  */
 
-import { Component, OnInit, signal, OnDestroy, effect, Inject, PLATFORM_ID, HostListener } from '@angular/core';
+import { Component, OnInit, signal, computed, OnDestroy, effect, Inject, PLATFORM_ID, HostListener } from '@angular/core';
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { FormsModule } from '@angular/forms';
@@ -766,17 +766,22 @@ import * as QRCode from 'qrcode';
                                 </div>
                                 <div>
                                     <h4 class="text-white font-bold text-sm">Transaction Signed</h4>
-                                    <p class="text-emerald-400 text-xs">Ready to broadcast</p>
+                                    <p class="text-emerald-400 text-xs">
+                                        {{ socket.isCoordinator() ? 'Ready to broadcast' : 'Awaiting Coordinator broadcast' }}
+                                    </p>
                                 </div>
                             </div>
-                            <div class="grid grid-cols-2 gap-3">
-                                <button (click)="copyHex()" class="py-2 px-3 bg-slate-800 hover:bg-slate-700 text-white text-xs font-bold rounded-lg border border-slate-700 transition flex items-center justify-center gap-2">
-                                    <lucide-icon [img]="copied() ? Check : Copy" class="w-3 h-3"></lucide-icon> {{ copied() ? 'Copied' : 'Copy Hex' }}
-                                </button>
-                                <button (click)="broadcastAndCopy()" class="py-2 px-3 bg-emerald-500 hover:bg-emerald-400 text-slate-950 text-xs font-bold rounded-lg transition flex items-center justify-center gap-2 text-center decoration-0">
-                                    Broadcast <lucide-icon [img]="ExternalLink" class="w-3 h-3"></lucide-icon>
-                                </button>
-                            </div>
+                            
+                            @if (socket.isCoordinator()) {
+                                <div class="grid grid-cols-2 gap-3">
+                                    <button (click)="copyHex()" class="py-2 px-3 bg-slate-800 hover:bg-slate-700 text-white text-xs font-bold rounded-lg border border-slate-700 transition flex items-center justify-center gap-2">
+                                        <lucide-icon [img]="copied() ? Check : Copy" class="w-3 h-3"></lucide-icon> {{ copied() ? 'Copied' : 'Copy Hex' }}
+                                    </button>
+                                    <button (click)="broadcastAndCopy()" class="py-2 px-3 bg-emerald-500 hover:bg-emerald-400 text-slate-950 text-xs font-bold rounded-lg transition flex items-center justify-center gap-2 text-center decoration-0">
+                                        Broadcast <lucide-icon [img]="ExternalLink" class="w-3 h-3"></lucide-icon>
+                                    </button>
+                                </div>
+                            }
                         </div>
                     } @else if (canFinalize) {  @if (socket.isCoordinator()) {
                         <button (click)="finalize()" class="w-full py-3.5 bg-emerald-500 hover:bg-emerald-400 text-slate-950 font-bold rounded-xl transition-all flex items-center justify-center gap-2 shadow-lg shadow-emerald-500/20 cursor-pointer">
@@ -818,7 +823,12 @@ export class RoomComponent implements OnInit, OnDestroy {
             $event.returnValue = true; 
         }
     }
-    
+
+    @HostListener('window:beforeunload')
+    onBeforeUnload() {
+        this.socket.gracefullyDisconnect();
+    }
+
     // -------------------------------------------------------------------------
     // Icons
     // -------------------------------------------------------------------------
@@ -896,7 +906,7 @@ export class RoomComponent implements OnInit, OnDestroy {
     // -------------------------------------------------------------------------
     // Workflow Flags & Inputs
     // -------------------------------------------------------------------------
-    public finalHex = signal<string | null>(null);
+    public finalHex = computed(() => this.socket.roomState()?.finalTxHex || null);
     public copied = signal(false);
     public inviteCopied = signal(false);
     public keyCopied = signal(false);
@@ -1004,7 +1014,8 @@ export class RoomComponent implements OnInit, OnDestroy {
 
     ngOnDestroy() {
         if (isPlatformBrowser(this.platformId)) {
-            this.socket.disconnect(true); 
+            this.socket.gracefullyDisconnect();
+            
             if (this.timerInterval) clearInterval(this.timerInterval);
         }
     }
@@ -1265,9 +1276,9 @@ export class RoomComponent implements OnInit, OnDestroy {
         
         const doFinalize = () => {
             const hex = this.socket.getFinalTxHex();
-            if (hex) {
-                this.finalHex.set(hex);
-                this.socket.logAction('Tx Finalized', 'Signatures merged successfully');
+            const txId = this.socket.getFinalTxId();
+            if (hex && txId) { 
+                this.socket.broadcastFinalization(hex, txId);
                 this.triggerConfetti();
             }
         };
@@ -1618,8 +1629,8 @@ export class RoomComponent implements OnInit, OnDestroy {
         doc.setFont('helvetica', 'bold');
         doc.text("Transaction Data", 20, y); y += 8;
         
-        // A. Transaction ID (The most important part)
-        const txId = this.socket.getFinalTxId();
+
+        const txId = this.socket.roomState()?.finalTxId;
         if (txId) {
             doc.setFontSize(10);
             doc.setTextColor(50);

--- a/apps/client/src/app/services/encryption/encryption.service.ts
+++ b/apps/client/src/app/services/encryption/encryption.service.ts
@@ -109,6 +109,22 @@ export class EncryptionService {
     }
   }
 
+  /**
+   * Deterministically blinds metadata using the room's encryption key as a salt.
+   */
+  async blindData(data: string, key: string): Promise<string> {
+    const encoder = new TextEncoder();
+    // Salt the data with the FBEK
+    const dataBuffer = encoder.encode(data + key); 
+    const hashBuffer = await crypto.subtle.digest('SHA-256', dataBuffer);
+    
+    // Return the first 16 characters of the hex hash
+    return Array.from(new Uint8Array(hashBuffer))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('')
+      .slice(0, 16); 
+  }
+
   // -------------------------------------------------------------------------
   // Private Helpers
   // -------------------------------------------------------------------------

--- a/apps/client/src/app/services/socket/socket.service.ts
+++ b/apps/client/src/app/services/socket/socket.service.ts
@@ -71,6 +71,7 @@ export class SocketService {
   private ws: WebSocket | null = null;
   private encryptionKey: string | null = null; 
   private fallbackVersion: string | null = null;
+  private blindFingerprintMap: Map<string, string> = new Map();
 
   // -------------------------------------------------------------------------
   // Signals
@@ -214,15 +215,21 @@ export class SocketService {
       if (!this.encryptionKey) return;
 
       const currentRoom = this.roomState();
-    
       const detectedFingerprint = this.getFingerprintFromPsbt(partialPsbtBase64);
+      
+      let blindedFingerprint: string | undefined;
 
       if (detectedFingerprint) {
-          const alreadySigned = this.signers().find(s => s.fingerprint === detectedFingerprint)?.signed;
+                   const alreadySigned = this.signers().find(s => s.fingerprint === detectedFingerprint)?.signed;
           if (alreadySigned) {
               console.warn(`Signature for ${detectedFingerprint} has already been applied.`);
               return;
           }
+ 
+          blindedFingerprint = await this.encryption.blindData(detectedFingerprint, this.encryptionKey);
+          
+          this.blindFingerprintMap.set(blindedFingerprint, detectedFingerprint);
+          this.blindFingerprintMap.set(detectedFingerprint, detectedFingerprint);
       }  
       
       let payloadToSend = partialPsbtBase64;
@@ -237,7 +244,7 @@ export class SocketService {
       
       this.send('UPLOAD_PARTIAL', { 
           data: { encryptedData },
-          fingerprint: detectedFingerprint 
+          fingerprint: blindedFingerprint
       });
   }
 
@@ -259,8 +266,27 @@ export class SocketService {
       this.send('RENAME_ROOM', { name });
   }
 
-  updateSignerLabel(fingerprint: string, label: string) {
-      this.send('UPDATE_LABEL', { fingerprint, label });
+  async updateSignerLabel(fingerprint: string, label: string) {
+    // 1. Harden the guard clause to handle undefined/null on load
+    const safeLabel = label || '';
+    const currentLabel = this.roomState()?.signerLabels?.[fingerprint] || '';
+    
+    // If the label hasn't actually changed, BREAK THE LOOP
+    if (currentLabel === safeLabel) return; 
+
+    const key = this.getRoomKey();
+    if (!key) return;
+
+    const blindedFingerprint = await this.encryption.blindData(fingerprint, key);
+    this.blindFingerprintMap.set(blindedFingerprint, fingerprint);
+    this.blindFingerprintMap.set(fingerprint, fingerprint); // Fallback
+
+    const encryptedLabel = await this.encryption.encrypt(safeLabel, key);
+
+    this.send('UPDATE_LABEL', { 
+        fingerprint: blindedFingerprint, 
+        label: encryptedLabel 
+    });
   }
 
   updateWhitelist(address: string, remove: boolean) {
@@ -329,6 +355,30 @@ export class SocketService {
         }
         return 0;
     } catch (e) { return 0; }
+  }
+
+  private async registerAllFingerprints(psbtData: string) {
+    const key = this.getRoomKey();
+    if (!key) return;
+
+    try {
+        const bytes = this.decodePsbt(psbtData);
+        const tx = Transaction.fromPSBT(bytes);
+        
+        for (let i = 0; i < tx.inputsLength; i++) {
+            const input = tx.getInput(i);
+            if (input.bip32Derivation) {
+                for (const [, meta] of input.bip32Derivation) {
+                    const fp = meta.fingerprint.toString(16).padStart(8, '0');
+                    const blinded = await this.encryption.blindData(fp, key);
+                    this.blindFingerprintMap.set(blinded, fp);
+                    this.blindFingerprintMap.set(fp, fp); // Fallback
+                }
+            }
+        }
+    } catch (e) {
+        console.error("Failed to parse fingerprints for blind map");
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -409,8 +459,24 @@ export class SocketService {
                 await this.handleNewPartial(msg);
                 break;
             case 'LABELS_UPDATED':
-                this.roomState.update(s => s ? { ...s, signerLabels: msg.signerLabels } : null);
+                {
+                const decryptedLabels: Record<string, string> = {};
+                const key = this.getRoomKey();
+                
+                if (key && msg.signerLabels) {
+                    for (const [blindedFp, encryptedLabel] of Object.entries(msg.signerLabels)) {
+                        try {
+                            const realFp = this.blindFingerprintMap.get(blindedFp) || blindedFp;
+                            const plainLabel = await this.encryption.decrypt(encryptedLabel as string, key);
+                            decryptedLabels[realFp] = plainLabel;
+                        } catch (e) {
+                            console.error("Failed to decrypt label for", blindedFp);
+                        }
+                    }
+                }
+                this.roomState.update(s => s ? { ...s, signerLabels: decryptedLabels } : null);
                 break;
+            }
             case 'ROOM_RENAMED':
                 this.roomState.update(s => s ? { ...s, roomName: msg.name } : null);
                 break;
@@ -476,27 +542,57 @@ export class SocketService {
     for (const sigData of decryptedHistory) {
         mergedPsbt = this.mergePsbts(mergedPsbt, sigData);
     }
+
+    // CRITICAL: Ensure the fingerprint map is fully populated BEFORE we decrypt the labels
+    if (mergedPsbt) {
+        await this.registerAllFingerprints(mergedPsbt);
+    }
+
+    const decryptedLabels: Record<string, string> = {};
+    if (msg.signerLabels && this.encryptionKey) {
+        for (const [blindedFp, encryptedLabel] of Object.entries(msg.signerLabels)) {
+            try {
+                // Now that the map is populated, this lookup will instantly succeed!
+                const realFp = this.blindFingerprintMap.get(blindedFp) || blindedFp;
+                const plainLabel = await this.encryption.decrypt(encryptedLabel as string, this.encryptionKey);
+                decryptedLabels[realFp] = plainLabel;
+            } catch (e) {
+                // Fallback for legacy rooms with plaintext labels
+                decryptedLabels[blindedFp] = encryptedLabel as string;
+            }
+        }
+    }
     
     this.roomState.set({
         ...this.getInitialState(msg.roomId, msg.protocolVersion || PROTOCOL_VERSION),
         ...msg,
         psbt: mergedPsbt,
         signatures: decryptedHistory,
+        signerLabels: Object.keys(decryptedLabels).length > 0 ? decryptedLabels : msg.signerLabels
     });
   }
 
   private async handleNewPartial(msg: any) {
     if (!msg.data?.encryptedData) return;
+    
     const decrypted = await this.encryption.decrypt(msg.data.encryptedData, this.encryptionKey!);
+    
+    let realFingerprint = msg.fingerprint;
+    if (msg.fingerprint) {
+        realFingerprint = this.blindFingerprintMap.get(msg.fingerprint) || msg.fingerprint;
+    }
+
     this.roomState.update(current => {
         if (!current) return null;
         return {
             ...current,
-            psbt: this.mergePsbts(current.psbt, decrypted),
+            psbt: this.mergePsbts(current.psbt, this.normalizePsbt(decrypted)),
             signatures: [...current.signatures, decrypted],
-            auditLog: msg.auditLog || current.auditLog
+            auditLog: msg.auditLog || current.auditLog 
         };
     });
+    
+    console.log(`Successfully merged new signature from signer: ${realFingerprint}`);
   }
 
   private decodePsbt(raw: string): Uint8Array {

--- a/apps/client/src/app/services/socket/socket.service.ts
+++ b/apps/client/src/app/services/socket/socket.service.ts
@@ -24,6 +24,7 @@ export interface AuditEntry {
   timestamp: number;
   event: string;
   detail?: string;
+  encryptedDetail?: string;
   user: string;
 }
 
@@ -241,10 +242,13 @@ export class SocketService {
       }
 
       const encryptedData = await this.encryption.encrypt(payloadToSend, this.encryptionKey);
-      
+      const logText = `Signer: ${detectedFingerprint || 'Unknown'}`;
+      const encryptedLogDetail = await this.encryption.encrypt(logText, this.encryptionKey);
+
       this.send('UPLOAD_PARTIAL', { 
           data: { encryptedData },
-          fingerprint: blindedFingerprint
+          fingerprint: blindedFingerprint,
+          encryptedLogDetail
       });
   }
 
@@ -262,16 +266,25 @@ export class SocketService {
       this.send('LOG_ACTION', { action, detail });
   }
 
-  renameRoom(name: string) {
-      this.send('RENAME_ROOM', { name });
-  }
+async renameRoom(newName: string) {
+    const key = this.getRoomKey();
+    if (!key) return;
 
-  async updateSignerLabel(fingerprint: string, label: string) {
-    // 1. Harden the guard clause to handle undefined/null on load
+    const encryptedName = await this.encryption.encrypt(newName, key);
+
+    const logText = `Renamed: ${newName}`;
+    const encryptedLogDetail = await this.encryption.encrypt(logText, key);
+
+    this.send('RENAME_ROOM', { 
+        encryptedName,
+        encryptedLogDetail
+    });
+}
+
+async updateSignerLabel(fingerprint: string, label: string) {
     const safeLabel = label || '';
     const currentLabel = this.roomState()?.signerLabels?.[fingerprint] || '';
     
-    // If the label hasn't actually changed, BREAK THE LOOP
     if (currentLabel === safeLabel) return; 
 
     const key = this.getRoomKey();
@@ -282,24 +295,81 @@ export class SocketService {
     this.blindFingerprintMap.set(fingerprint, fingerprint); // Fallback
 
     const encryptedLabel = await this.encryption.encrypt(safeLabel, key);
+    
+    const logText = `${safeLabel} (${fingerprint})`;
+    const encryptedLogDetail = await this.encryption.encrypt(logText, key);
 
     this.send('UPDATE_LABEL', { 
         fingerprint: blindedFingerprint, 
-        label: encryptedLabel 
+        label: encryptedLabel,
+        encryptedLogDetail
     });
   }
 
-  updateWhitelist(address: string, remove: boolean) {
-      this.send('UPDATE_WHITELIST', { address, remove });
+  async updateWhitelist(address: string, remove: boolean) {
+    const key = this.getRoomKey();
+    if (!key) return;
+
+    const currentList = this.roomState()?.whitelist || [];
+    let newList = [];
+    
+    if (remove) {
+        newList = currentList.filter(a => a !== address);
+    } else {
+        if (!currentList.includes(address)) {
+            newList = [...currentList, address];
+        } else {
+            newList = [...currentList];
+        }
+    }
+
+    const encryptedWhitelist = await this.encryption.encrypt(JSON.stringify(newList), key);
+    
+    const logText = remove ? `Removed address from whitelist` : `Added address to whitelist`;
+    const encryptedLogDetail = await this.encryption.encrypt(logText, key);
+
+    this.send('UPDATE_WHITELIST', { 
+        encryptedWhitelist,
+        encryptedLogDetail
+    });
   }
 
   toggleLock(locked: boolean) {
       this.send('TOGGLE_LOCK', { locked });
   }
 
-  updateWhitelistBatch(addresses: string[], remove: boolean) {
-        if (addresses.length === 0) return;
-        this.send('WHITELIST_BATCH_UPDATE', { addresses, remove });
+  async updateWhitelistBatch(addresses: string[], remove: boolean) {
+        const key = this.getRoomKey();
+        if (!key) return;
+
+        // 1. Get the current state of the whitelist
+        const currentList = this.roomState()?.whitelist || [];
+        let newList: string[] = [];
+
+        // 2. Calculate the new array locally
+        if (remove) {
+            // Filter out any addresses that are in the batch removal list
+            newList = currentList.filter(a => !addresses.includes(a));
+        } else {
+            // Merge the current list with the new batch, and use a Set to deduplicate
+            const combined = [...currentList, ...addresses];
+            newList = Array.from(new Set(combined)); 
+        }
+
+        // 3. Encrypt the entire resulting array
+        const encryptedWhitelist = await this.encryption.encrypt(JSON.stringify(newList), key);
+        
+        // 4. Create the secure audit log string
+        const action = remove ? 'Removed' : 'Verified';
+        const logText = `${action} ${addresses.length} batch address(es)`;
+        const encryptedLogDetail = await this.encryption.encrypt(logText, key);
+
+        // 5. Send it using the exact same standard UPDATE_WHITELIST event!
+        // The server doesn't care if it's 1 or 50 addresses, it just saves the blob.
+        this.send('UPDATE_WHITELIST', { 
+            encryptedWhitelist,
+            encryptedLogDetail
+        });
     }
 
   // -------------------------------------------------------------------------
@@ -478,10 +548,22 @@ export class SocketService {
                 break;
             }
             case 'ROOM_RENAMED':
-                this.roomState.update(s => s ? { ...s, roomName: msg.name } : null);
+                 if (msg.encryptedName && this.encryptionKey) {
+                    try {
+                        const decName = await this.encryption.decrypt(msg.encryptedName, this.encryptionKey);
+                        this.roomState.update(s => s ? { ...s, roomName: decName } : null);
+                    } catch (e) {
+                        console.error("Failed to decrypt renamed room", e);
+                    }
+                }
                 break;
             case 'LOG_UPDATE':
-                this.roomState.update(s => s ? { ...s, auditLog: msg.auditLog } : null);
+                try {
+                    const decryptedLog = await this.decryptAuditLog(msg.auditLog || []);
+                    this.roomState.update(s => s ? { ...s, auditLog: decryptedLog } : null);
+                } catch (e) {
+                    console.error("Failed to decrypt audit log update", e);
+                }
                 break;
             case 'CONNECTIONS_UPDATE':
                 this.roomState.update(s => s ? { ...s, connectedCount: msg.count } : null);
@@ -494,8 +576,19 @@ export class SocketService {
                 this.isClosed.set(true);
                 this.disconnect(false);
                 break;
-            case 'WHITELIST_UPDATED':
-                this.roomState.update(s => s ? { ...s, whitelist: msg.whitelist } : null);
+            case 'WHITELIST_UPDATED': 
+                {
+                    const key = this.getRoomKey();
+                    if (key && msg.encryptedWhitelist) {
+                        try {
+                            const decW = await this.encryption.decrypt(msg.encryptedWhitelist, key);
+                            const newWhitelist = JSON.parse(decW);
+                            this.roomState.update(s => s ? { ...s, whitelist: newWhitelist } : null);
+                        } catch (e) {
+                            console.error("Failed to decrypt updated whitelist", e);
+                        }
+                    }
+                }
                 break;
             case 'LOCK_UPDATED':
                 this.roomState.update(s => s ? { ...s, isLocked: msg.isLocked } : null);
@@ -529,11 +622,18 @@ export class SocketService {
     const decryptedHistory: string[] = [];
     if (msg.signatures?.length) {
         for (const sig of msg.signatures) {
-            if (sig?.encryptedData) {
-                const dec = await this.encryption.decrypt(sig.encryptedData, this.encryptionKey!);
-                decryptedHistory.push(this.normalizePsbt(dec)); 
-            } else if (typeof sig === 'string') {
-                decryptedHistory.push(this.normalizePsbt(sig));
+            try {
+                if (sig?.encryptedData) {
+                    const dec = await this.encryption.decrypt(sig.encryptedData, this.encryptionKey!);
+                    decryptedHistory.push(this.normalizePsbt(dec)); 
+                } else if (typeof sig === 'string') {
+                    const dec = await this.encryption.decrypt(sig, this.encryptionKey!);
+                    decryptedHistory.push(this.normalizePsbt(dec));
+                }
+            } catch (e) {
+                if (typeof sig === 'string') {
+                    decryptedHistory.push(this.normalizePsbt(sig));
+                }
             }
         }
     }
@@ -562,13 +662,37 @@ export class SocketService {
             }
         }
     }
-    
+
+    const decryptedLog = await this.decryptAuditLog(msg.auditLog || []);
+
+    let decryptedWhitelist: string[] = [];
+    if (msg.whitelist && typeof msg.whitelist === 'string') {
+        try {
+            const decW = await this.encryption.decrypt(msg.whitelist, this.encryptionKey!);
+            decryptedWhitelist = JSON.parse(decW);
+        } catch(e) { console.error("Failed to decrypt whitelist"); }
+    } else if (Array.isArray(msg.whitelist)) {
+        decryptedWhitelist = msg.whitelist;
+    }
+
+    let decryptedRoomName = msg.roomName || 'Untitled Room';
+    if (msg.roomName && msg.roomName !== 'Untitled Room') {
+        try {
+            decryptedRoomName = await this.encryption.decrypt(msg.roomName, this.encryptionKey!);
+        } catch (e) {
+            decryptedRoomName = msg.roomName; 
+        }
+    }
+
     this.roomState.set({
         ...this.getInitialState(msg.roomId, msg.protocolVersion || PROTOCOL_VERSION),
         ...msg,
         psbt: mergedPsbt,
         signatures: decryptedHistory,
-        signerLabels: Object.keys(decryptedLabels).length > 0 ? decryptedLabels : msg.signerLabels
+        signerLabels: Object.keys(decryptedLabels).length > 0 ? decryptedLabels : msg.signerLabels,
+        auditLog: decryptedLog,
+        whitelist: decryptedWhitelist,
+        roomName: decryptedRoomName
     });
   }
 
@@ -582,13 +706,18 @@ export class SocketService {
         realFingerprint = this.blindFingerprintMap.get(msg.fingerprint) || msg.fingerprint;
     }
 
+    let updatedLog = this.roomState()?.auditLog || [];
+    if (msg.auditLog) {
+        updatedLog = await this.decryptAuditLog(msg.auditLog);
+    }
+
     this.roomState.update(current => {
         if (!current) return null;
         return {
             ...current,
             psbt: this.mergePsbts(current.psbt, this.normalizePsbt(decrypted)),
             signatures: [...current.signatures, decrypted],
-            auditLog: msg.auditLog || current.auditLog 
+            auditLog: updatedLog 
         };
     });
     
@@ -752,5 +881,25 @@ export class SocketService {
         const getX = (k: Uint8Array) => k.length === 33 ? k.slice(1) : k.length === 65 ? k.slice(1, 33) : k;
         return hex.encode(getX(k1)) === hex.encode(getX(k2));
     } catch (e) { return false; }
+  }
+
+  private async decryptAuditLog(log: AuditEntry[]): Promise<AuditEntry[]> {
+      const key = this.getRoomKey();
+      if (!key || !log) return log;
+      
+      const decryptedLog = [];
+      for (const entry of log) {
+          if (entry.encryptedDetail) {
+              try {
+                  const dec = await this.encryption.decrypt(entry.encryptedDetail, key);
+                  decryptedLog.push({ ...entry, detail: dec });
+              } catch (e) {
+                  decryptedLog.push({ ...entry, detail: '*** Encrypted Data ***' });
+              }
+          } else {
+              decryptedLog.push(entry);
+          }
+      }
+      return decryptedLog;
   }
 }

--- a/apps/client/src/app/services/socket/socket.service.ts
+++ b/apps/client/src/app/services/socket/socket.service.ts
@@ -37,6 +37,8 @@ export interface RoomState {
   // Transaction Data
   psbt: string; 
   signatures: string[]; 
+  finalTxHex?: string;
+  finalTxId?: string;
   
   // Metadata
   connectedCount: number;
@@ -73,6 +75,8 @@ export class SocketService {
   private encryptionKey: string | null = null; 
   private fallbackVersion: string | null = null;
   private blindFingerprintMap: Map<string, string> = new Map();
+  private currentSessionId?: string;
+  private hasAnnouncedJoin = false;
 
   // -------------------------------------------------------------------------
   // Signals
@@ -242,13 +246,18 @@ export class SocketService {
       }
 
       const encryptedData = await this.encryption.encrypt(payloadToSend, this.encryptionKey);
-      const logText = `Signer: ${detectedFingerprint || 'Unknown'}`;
-      const encryptedLogDetail = await this.encryption.encrypt(logText, this.encryptionKey);
+      
+      const role = this.isCoordinator() ? 'Coordinator' : `Guest (${this.currentSessionId || 'Unknown'})`;
+      const encryptedLogBlob = await this.createSecureLogBlob(
+          'Signature Uploaded',
+          `Signer: ${detectedFingerprint || 'Unknown'}`,
+          role
+      );
 
       this.send('UPLOAD_PARTIAL', { 
           data: { encryptedData },
           fingerprint: blindedFingerprint,
-          encryptedLogDetail
+          encryptedLogBlob 
       });
   }
 
@@ -262,8 +271,14 @@ export class SocketService {
     this.send('CLOSE_ROOM'); 
   }
 
-  logAction(action: string, detail: string = '') {
-      this.send('LOG_ACTION', { action, detail });
+  async logAction(action: string, detail: string) {
+      const encryptedLogBlob = await this.createSecureLogBlob(
+          action, 
+          detail, 
+          this.isCoordinator() ? 'Coordinator' : `Guest (${this.currentSessionId || 'Unknown'})`
+      );
+      
+      this.send('LOG_ACTION', { encryptedLogBlob });
   }
 
 async renameRoom(newName: string) {
@@ -272,12 +287,14 @@ async renameRoom(newName: string) {
 
     const encryptedName = await this.encryption.encrypt(newName, key);
 
-    const logText = `Renamed: ${newName}`;
-    const encryptedLogDetail = await this.encryption.encrypt(logText, key);
-
+    const encryptedLogBlob = await this.createSecureLogBlob(
+        'Room Renamed', 
+        `Renamed: ${newName}`, 
+        'Coordinator'
+    );
     this.send('RENAME_ROOM', { 
         encryptedName,
-        encryptedLogDetail
+        encryptedLogBlob 
     });
 }
 
@@ -296,13 +313,16 @@ async updateSignerLabel(fingerprint: string, label: string) {
 
     const encryptedLabel = await this.encryption.encrypt(safeLabel, key);
     
-    const logText = `${safeLabel} (${fingerprint})`;
-    const encryptedLogDetail = await this.encryption.encrypt(logText, key);
+    const encryptedLogBlob = await this.createSecureLogBlob(
+        'Label Updated',
+        `${safeLabel} (${fingerprint})`,
+        'Coordinator'
+    );
 
     this.send('UPDATE_LABEL', { 
         fingerprint: blindedFingerprint, 
         label: encryptedLabel,
-        encryptedLogDetail
+        encryptedLogBlob 
     });
   }
 
@@ -325,12 +345,19 @@ async updateSignerLabel(fingerprint: string, label: string) {
 
     const encryptedWhitelist = await this.encryption.encrypt(JSON.stringify(newList), key);
     
-    const logText = remove ? `Removed address from whitelist` : `Added address to whitelist`;
-    const encryptedLogDetail = await this.encryption.encrypt(logText, key);
+    const shortAddr = address.length > 5 ? address.slice(-5) : address;
+    const actionWord = remove ? 'Removed' : 'Added';
+    const logText = `${actionWord} ...${shortAddr} to whitelist`;
+    
+    const encryptedLogBlob = await this.createSecureLogBlob(
+        'Whitelist Updated',
+        logText,
+        'Coordinator'
+    );
 
     this.send('UPDATE_WHITELIST', { 
         encryptedWhitelist,
-        encryptedLogDetail
+        encryptedLogBlob 
     });
   }
 
@@ -342,35 +369,52 @@ async updateSignerLabel(fingerprint: string, label: string) {
         const key = this.getRoomKey();
         if (!key) return;
 
-        // 1. Get the current state of the whitelist
         const currentList = this.roomState()?.whitelist || [];
         let newList: string[] = [];
 
-        // 2. Calculate the new array locally
         if (remove) {
-            // Filter out any addresses that are in the batch removal list
             newList = currentList.filter(a => !addresses.includes(a));
         } else {
-            // Merge the current list with the new batch, and use a Set to deduplicate
             const combined = [...currentList, ...addresses];
             newList = Array.from(new Set(combined)); 
         }
 
-        // 3. Encrypt the entire resulting array
         const encryptedWhitelist = await this.encryption.encrypt(JSON.stringify(newList), key);
         
-        // 4. Create the secure audit log string
-        const action = remove ? 'Removed' : 'Verified';
-        const logText = `${action} ${addresses.length} batch address(es)`;
-        const encryptedLogDetail = await this.encryption.encrypt(logText, key);
+        const actionWord = remove ? 'Removed' : 'Verified';
+        const logText = `${actionWord} ${addresses.length} batch address(es)`;
+        
+        const encryptedLogBlob = await this.createSecureLogBlob(
+            'Whitelist Updated',
+            logText,
+            'Coordinator'
+        );
 
-        // 5. Send it using the exact same standard UPDATE_WHITELIST event!
-        // The server doesn't care if it's 1 or 50 addresses, it just saves the blob.
         this.send('UPDATE_WHITELIST', { 
             encryptedWhitelist,
-            encryptedLogDetail
+            encryptedLogBlob 
         });
     }
+
+    async broadcastFinalization(finalTxHex: string, finalTxId: string) {
+      const key = this.getRoomKey();
+      if (!key) return;
+
+      const encryptedFinalTxHex = await this.encryption.encrypt(finalTxHex, key);
+      const encryptedFinalTxId = await this.encryption.encrypt(finalTxId, key);
+
+      const encryptedLogBlob = await this.createSecureLogBlob(
+          'Tx Finalized',
+          'Signatures merged successfully',
+          'Coordinator'
+      );
+      
+      this.send('TX_FINALIZED', {
+          encryptedFinalTxHex,
+          encryptedFinalTxId,
+          encryptedLogBlob
+      });
+  }
 
   // -------------------------------------------------------------------------
   // PSBT & Crypto Logic
@@ -494,6 +538,7 @@ async updateSignerLabel(fingerprint: string, label: string) {
   }
 
   private reset() {
+    this.hasAnnouncedJoin = false;
     this.roomState.set(null);
     this.role.set('guest');
     this.isClosed.set(false); 
@@ -522,6 +567,9 @@ async updateSignerLabel(fingerprint: string, label: string) {
 
     try {
         switch (msg.type) {
+            case 'SESSION_CONNECTED':
+                this.currentSessionId = msg.sessionId;
+                break;
             case 'STATE_SYNC':
                 await this.handleStateSync(msg);
                 break;
@@ -569,7 +617,15 @@ async updateSignerLabel(fingerprint: string, label: string) {
                 this.roomState.update(s => s ? { ...s, connectedCount: msg.count } : null);
                 break;
             case 'ROLE_UPDATE':
-                this.role.set(msg.role); 
+                {
+                    this.role.set(msg.role); 
+        
+                    if (!this.hasAnnouncedJoin && msg.role === 'admin') {
+                        this.hasAnnouncedJoin = true;
+                        this.createSecureLogBlob('User Joined', `Session: ${this.currentSessionId}`, 'Coordinator')
+                            .then(blob => this.send('LOG_ACTION', { encryptedLogBlob: blob }));
+                    }
+                }
                 break;
             case 'ROOM_CLOSED':
                 if (msg.finalLog) this.roomState.update(s => s ? { ...s, auditLog: msg.finalLog } : null);
@@ -592,6 +648,18 @@ async updateSignerLabel(fingerprint: string, label: string) {
                 break;
             case 'LOCK_UPDATED':
                 this.roomState.update(s => s ? { ...s, isLocked: msg.isLocked } : null);
+                break;
+            case 'TX_FINALIZED_BROADCAST':
+                if (msg.encryptedFinalTxHex && msg.encryptedFinalTxId && this.encryptionKey) {
+                    try {
+                        const decHex = await this.encryption.decrypt(msg.encryptedFinalTxHex, this.encryptionKey);
+                        const decId = await this.encryption.decrypt(msg.encryptedFinalTxId, this.encryptionKey);
+                        
+                        this.roomState.update(s => s ? { ...s, finalTxHex: decHex, finalTxId: decId } : null);
+                    } catch (e) {
+                        console.error("Failed to decrypt final tx data", e);
+                    }
+                }
                 break;
             case 'ERROR_LOCKED':
                 this.isLockedOut.set(true);
@@ -643,7 +711,6 @@ async updateSignerLabel(fingerprint: string, label: string) {
         mergedPsbt = this.mergePsbts(mergedPsbt, sigData);
     }
 
-    // CRITICAL: Ensure the fingerprint map is fully populated BEFORE we decrypt the labels
     if (mergedPsbt) {
         await this.registerAllFingerprints(mergedPsbt);
     }
@@ -651,14 +718,17 @@ async updateSignerLabel(fingerprint: string, label: string) {
     const decryptedLabels: Record<string, string> = {};
     if (msg.signerLabels && this.encryptionKey) {
         for (const [blindedFp, encryptedLabel] of Object.entries(msg.signerLabels)) {
-            try {
-                // Now that the map is populated, this lookup will instantly succeed!
-                const realFp = this.blindFingerprintMap.get(blindedFp) || blindedFp;
-                const plainLabel = await this.encryption.decrypt(encryptedLabel as string, this.encryptionKey);
-                decryptedLabels[realFp] = plainLabel;
-            } catch (e) {
-                // Fallback for legacy rooms with plaintext labels
-                decryptedLabels[blindedFp] = encryptedLabel as string;
+            const labelStr = encryptedLabel as string;
+            const realFp = this.blindFingerprintMap.get(blindedFp) || blindedFp;
+            
+            if (labelStr.length >= 40) {
+                try {
+                    decryptedLabels[realFp] = await this.encryption.decrypt(labelStr, this.encryptionKey);
+                } catch (e) {
+                    decryptedLabels[realFp] = labelStr;
+                }
+            } else {
+                decryptedLabels[realFp] = labelStr;
             }
         }
     }
@@ -675,13 +745,37 @@ async updateSignerLabel(fingerprint: string, label: string) {
         decryptedWhitelist = msg.whitelist;
     }
 
-    let decryptedRoomName = msg.roomName || 'Untitled Room';
-    if (msg.roomName && msg.roomName !== 'Untitled Room') {
-        try {
-            decryptedRoomName = await this.encryption.decrypt(msg.roomName, this.encryptionKey!);
-        } catch (e) {
-            decryptedRoomName = msg.roomName; 
+    let decryptedRoomName = 'Untitled Room';
+    if (msg.roomName && this.encryptionKey) {
+        if (msg.roomName.length >= 40) {
+            try {
+                decryptedRoomName = await this.encryption.decrypt(msg.roomName, this.encryptionKey);
+            } catch (e) {
+                decryptedRoomName = msg.roomName; 
+            }
+        } else {
+            decryptedRoomName = msg.roomName;
         }
+    }
+
+    let finalTxHex = msg.finalTxHex; 
+    let finalTxId = msg.finalTxId;  
+    
+    if (msg.encryptedFinalTxHex && msg.encryptedFinalTxId && this.encryptionKey) {
+        try {
+            finalTxHex = await this.encryption.decrypt(msg.encryptedFinalTxHex, this.encryptionKey);
+            finalTxId = await this.encryption.decrypt(msg.encryptedFinalTxId, this.encryptionKey);
+        } catch (e) {
+            console.error("Failed to decrypt final TX data in sync", e);
+        }
+    }
+
+    const hasAdminToken = !!sessionStorage.getItem(`admin_token_${msg.roomId}`);
+
+    if (!this.hasAnnouncedJoin && this.currentSessionId && !hasAdminToken) {
+        this.hasAnnouncedJoin = true;
+        this.createSecureLogBlob('User Joined', `Session: ${this.currentSessionId}`, 'Guest')
+            .then(blob => this.send('LOG_ACTION', { encryptedLogBlob: blob }));
     }
 
     this.roomState.set({
@@ -692,7 +786,9 @@ async updateSignerLabel(fingerprint: string, label: string) {
         signerLabels: Object.keys(decryptedLabels).length > 0 ? decryptedLabels : msg.signerLabels,
         auditLog: decryptedLog,
         whitelist: decryptedWhitelist,
-        roomName: decryptedRoomName
+        roomName: decryptedRoomName,
+        finalTxHex: finalTxHex, 
+        finalTxId: finalTxId
     });
   }
 
@@ -706,18 +802,12 @@ async updateSignerLabel(fingerprint: string, label: string) {
         realFingerprint = this.blindFingerprintMap.get(msg.fingerprint) || msg.fingerprint;
     }
 
-    let updatedLog = this.roomState()?.auditLog || [];
-    if (msg.auditLog) {
-        updatedLog = await this.decryptAuditLog(msg.auditLog);
-    }
-
     this.roomState.update(current => {
         if (!current) return null;
         return {
             ...current,
             psbt: this.mergePsbts(current.psbt, this.normalizePsbt(decrypted)),
-            signatures: [...current.signatures, decrypted],
-            auditLog: updatedLog 
+            signatures: [...current.signatures, decrypted]
         };
     });
     
@@ -883,23 +973,63 @@ async updateSignerLabel(fingerprint: string, label: string) {
     } catch (e) { return false; }
   }
 
-  private async decryptAuditLog(log: AuditEntry[]): Promise<AuditEntry[]> {
+  private async decryptAuditLog(serverLogArray: any[]): Promise<AuditEntry[]> {
       const key = this.getRoomKey();
-      if (!key || !log) return log;
+      if (!key || !serverLogArray || !Array.isArray(serverLogArray)) return [];
       
-      const decryptedLog = [];
-      for (const entry of log) {
-          if (entry.encryptedDetail) {
-              try {
-                  const dec = await this.encryption.decrypt(entry.encryptedDetail, key);
-                  decryptedLog.push({ ...entry, detail: dec });
-              } catch (e) {
-                  decryptedLog.push({ ...entry, detail: '*** Encrypted Data ***' });
+      const decryptedLog: AuditEntry[] = [];
+      
+      for (const encryptedBlob of serverLogArray) {
+          if (!encryptedBlob) continue; 
+
+          try {
+              if (typeof encryptedBlob === 'string') {
+                  const dec = await this.encryption.decrypt(encryptedBlob, key);
+                  const entry = JSON.parse(dec);
+                  if (entry) decryptedLog.push(entry);
+              } else {
+                  decryptedLog.push(encryptedBlob);
               }
-          } else {
-              decryptedLog.push(entry);
+          } catch (e) {
+              decryptedLog.push({ timestamp: 0, event: 'Encrypted Data', user: 'Unknown' });
           }
       }
-      return decryptedLog;
+      
+      return decryptedLog
+          .filter(entry => entry !== null && typeof entry === 'object')
+          .sort((a, b) => (a.timestamp || 0) - (b.timestamp || 0));
+  }
+
+  private async createSecureLogBlob(event: string, detail: string, user: string): Promise<string> {
+      const key = this.getRoomKey();
+      if (!key) return '';
+      
+      const logEntry = {
+          timestamp: Date.now(),
+          event: event,
+          detail: detail,
+          user: user
+      };
+      
+      return await this.encryption.encrypt(JSON.stringify(logEntry), key);
+  }
+
+  async gracefullyDisconnect() {
+      if (this.currentSessionId && this.status() === 'connected') {
+          try {
+              const encryptedLogBlob = await this.createSecureLogBlob(
+                  'User Left', 
+                  `Session ID: ${this.currentSessionId}`, 
+                  'Guest'
+              );
+              this.send('LOG_ACTION', { encryptedLogBlob });
+          } catch (e) {
+              console.error("Failed to send disconnect log");
+          }
+      }
+      
+      setTimeout(() => {
+          this.disconnect();
+      }, 50);
   }
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -127,7 +127,7 @@ app.post('/api/room', async (c) => {
     body: JSON.stringify({ encryptedPsbt, adminToken, roomId, network, protocolVersion })
   }));
 
-  return c.json({ roomId, adminToken, socketUrl: `/api/room/${roomId}/websocket` });
+  return c.json({ roomId, socketUrl: `/api/room/${roomId}/websocket` });
 });
 
 // WebSocket Upgrade Handler

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -300,7 +300,10 @@ export class SigningRoom implements DurableObject {
               return webSocket.send(JSON.stringify({ type: 'ERROR', message: 'Room locked due to multiple failed attempts' }));
             }
 
-            if (msg.token === this.roomState.adminToken) {
+            const hashBuffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(msg.token));
+            const incomingHash = Array.from(new Uint8Array(hashBuffer)).map(b => b.toString(16).padStart(2, '0')).join('');
+
+            if (incomingHash === this.roomState.adminToken) {
               this.authFailures = 0; 
               this.sessions.set(webSocket, { ...session!, role: 'admin' });
               webSocket.send(JSON.stringify({ type: 'ROLE_UPDATE', role: 'admin' }));
@@ -318,11 +321,11 @@ export class SigningRoom implements DurableObject {
         if (msg.type === 'UPDATE_LABEL' && session?.role === 'admin') {
             if (!this.roomState.signerLabels) this.roomState.signerLabels = {};
 
-            const cleanLabel = sanitizeInput(msg.label, 120); 
+            const cleanLabel = sanitizeInput(msg.label, 1024); 
             this.roomState.signerLabels[msg.fingerprint] = cleanLabel;
             
             await this.state.storage.put('data', this.roomState);
-            this.log('Label Updated', `${msg.fingerprint} -> ${cleanLabel}`, userLabel);
+            this.log('Label Updated', `Signer Alias Modified`, 'Coordinator');
             this.broadcast({ type: 'LABELS_UPDATED', signerLabels: this.roomState.signerLabels });
         }
 

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -161,15 +161,33 @@ export class SigningRoom implements DurableObject {
     });
   }
 
-  async log(event: string, detail: string = '', user: string = 'System') {
+  // async log(event: string, detail: string = '', user: string = 'System') {
+  //   if (!this.roomState) return;
+  //   if (!this.roomState.auditLog) this.roomState.auditLog = [];
+  //   // Keep log reasonable size
+  //   if (this.roomState.auditLog.length > 100) this.roomState.auditLog.shift();
+    
+  //   this.roomState.auditLog.push({ timestamp: Date.now(), event, detail, user });
+  //   await this.state.storage.put('data', this.roomState);
+  // }
+
+  async log(event: string, detail: string = '', user: string = 'System', encryptedDetail?: string) {
     if (!this.roomState) return;
     if (!this.roomState.auditLog) this.roomState.auditLog = [];
-    // Keep log reasonable size
+    
     if (this.roomState.auditLog.length > 100) this.roomState.auditLog.shift();
     
-    this.roomState.auditLog.push({ timestamp: Date.now(), event, detail, user });
+    this.roomState.auditLog.push({ 
+        timestamp: Date.now(), 
+        event, 
+        detail, 
+        user, 
+        encryptedDetail 
+    });
+    
     await this.state.storage.put('data', this.roomState);
   }
+
 
   async fetch(request: Request) {
     const url = new URL(request.url);
@@ -321,25 +339,25 @@ export class SigningRoom implements DurableObject {
         if (msg.type === 'UPDATE_LABEL' && session?.role === 'admin') {
             if (!this.roomState.signerLabels) this.roomState.signerLabels = {};
 
-            const cleanLabel = sanitizeInput(msg.label, 1024); 
-            this.roomState.signerLabels[msg.fingerprint] = cleanLabel;
+            // msg.label is now a secure Base64 blob, so no need to sanitize!
+            this.roomState.signerLabels[msg.fingerprint] = msg.label;
             
             await this.state.storage.put('data', this.roomState);
-            this.log('Label Updated', `Signer Alias Modified`, 'Coordinator');
+            
+            // Pass the encryptedLogDetail as the 4th parameter!
+            this.log('Label Updated', '', 'Coordinator', msg.encryptedLogDetail);
             this.broadcast({ type: 'LABELS_UPDATED', signerLabels: this.roomState.signerLabels });
         }
 
         // Rename Room (Admin Only)
         if (msg.type === 'RENAME_ROOM' && session?.role === 'admin') {
-          const oldName = this.roomState.roomName;
-          
-          const cleanName = sanitizeInput(msg.name, 120);
-          this.roomState.roomName = cleanName;
-          
+          this.roomState.roomName = msg.encryptedName; 
           await this.state.storage.put('data', this.roomState);
-          this.log('Room Renamed', `${oldName} -> ${cleanName}`, userLabel);
-          this.broadcast({ type: 'ROOM_RENAMED', name: this.roomState.roomName });
-      }
+          
+          this.log('Room Renamed', '', 'Coordinator', msg.encryptedLogDetail);
+          
+          this.broadcast({ type: 'ROOM_RENAMED', encryptedName: msg.encryptedName });
+        }
 
         // Action Logging
         if (msg.type === 'LOG_ACTION') {
@@ -347,18 +365,19 @@ export class SigningRoom implements DurableObject {
           this.broadcast({ type: 'LOG_UPDATE', auditLog: this.roomState.auditLog });
         }
 
-        // PSBT Chunk Upload (Blind Relay)
+        // PSBT Chunk Upload
         if (msg.type === 'UPLOAD_PARTIAL') {
           if (msg.data?.encryptedData && msg.data.encryptedData.length > MAX_PAYLOAD_SIZE_BYTES) return;
-          if (this.roomState.signatures.length >= 100) { // Safety Cap
+          if (this.roomState.signatures.length >= 100) { 
             webSocket.send(JSON.stringify({ type: 'ERROR', message: 'Signature limit reached.' }));
             return;
           }
-          this.roomState.signatures.push(msg.data);
-          const detail = msg.fingerprint ? `Signer: ${msg.fingerprint}` : 'Unknown Signer';
-          await this.log('Signature Uploaded', detail, userLabel);
+          
+          this.roomState.signatures.push(msg.data.encryptedData); 
           await this.state.storage.put('data', this.roomState);
-          this.broadcast({ type: 'NEW_PARTIAL_DATA', data: msg.data, signerId: msg.signerId, auditLog: this.roomState.auditLog });
+          
+          this.log('Signature Uploaded', '', userLabel, msg.encryptedLogDetail);
+          this.broadcast({ type: 'NEW_PARTIAL_DATA', data: msg.data, fingerprint: msg.fingerprint, auditLog: this.roomState.auditLog });
         }
 
         // Destroy Room (Admin Only)
@@ -372,27 +391,13 @@ export class SigningRoom implements DurableObject {
 
         // Whitelist Management (Admin Only)
         if (msg.type === 'UPDATE_WHITELIST' && session?.role === 'admin') {
-          const list = this.roomState.whitelist || [];
-          if (msg.remove) this.roomState.whitelist = list.filter((a: string) => a !== msg.address);
-          else if (!list.includes(msg.address)) this.roomState.whitelist.push(msg.address);
+          this.roomState.whitelist = msg.encryptedWhitelist; 
           await this.state.storage.put('data', this.roomState);
-          this.log('Whitelist Updated', `${msg.remove ? 'Removed' : 'Added'} ${msg.address}`, userLabel);
-          this.broadcast({ type: 'WHITELIST_UPDATED', whitelist: this.roomState.whitelist });
+          
+          this.log('Whitelist Updated', '', userLabel, msg.encryptedLogDetail);
+          this.broadcast({ type: 'WHITELIST_UPDATED', encryptedWhitelist: msg.encryptedWhitelist });
         }
 
-        // Batch Whitelist Management (Admin Only)
-        if (msg.type === 'WHITELIST_BATCH_UPDATE' && session?.role === 'admin') {
-          const list = this.roomState.whitelist || [];
-          if (msg.remove) {
-            this.roomState.whitelist = list.filter((a: string) => !msg.addresses.includes(a));
-          } else {
-            const newAddresses = msg.addresses.filter(addr => !list.includes(addr));
-            this.roomState.whitelist = [...list, ...newAddresses];
-          }
-          await this.state.storage.put('data', this.roomState);
-          this.log('Whitelist Updated (Batch)', `${msg.remove ? 'Removed' : 'Added'} ${msg.addresses.length} addresses`, userLabel);
-          this.broadcast({ type: 'WHITELIST_UPDATED', whitelist: this.roomState.whitelist });
-        }
 
         // Room Lock (Admin Only)
         if (msg.type === 'TOGGLE_LOCK' && session?.role === 'admin') {

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -100,7 +100,7 @@ app.use('/*', async (c, next) => {
 app.get('/api/health', (c) => {
   return c.json({ 
     status: 'healthy', 
-    version: '1.4.2', 
+    version: '1.5.0', 
     timestamp: Date.now() 
   });
 });
@@ -161,31 +161,16 @@ export class SigningRoom implements DurableObject {
     });
   }
 
-  // async log(event: string, detail: string = '', user: string = 'System') {
-  //   if (!this.roomState) return;
-  //   if (!this.roomState.auditLog) this.roomState.auditLog = [];
-  //   // Keep log reasonable size
-  //   if (this.roomState.auditLog.length > 100) this.roomState.auditLog.shift();
-    
-  //   this.roomState.auditLog.push({ timestamp: Date.now(), event, detail, user });
-  //   await this.state.storage.put('data', this.roomState);
-  // }
-
-  async log(event: string, detail: string = '', user: string = 'System', encryptedDetail?: string) {
+  async log(encryptedLogBlob: string) {
     if (!this.roomState) return;
-    if (!this.roomState.auditLog) this.roomState.auditLog = [];
+    if (!this.roomState.auditLog) this.roomState.auditLog = []; 
     
-    if (this.roomState.auditLog.length > 100) this.roomState.auditLog.shift();
+    if (this.roomState.auditLog.length > 2000) this.roomState.auditLog.shift();
     
-    this.roomState.auditLog.push({ 
-        timestamp: Date.now(), 
-        event, 
-        detail, 
-        user, 
-        encryptedDetail 
-    });
+    this.roomState.auditLog.push(encryptedLogBlob);
     
     await this.state.storage.put('data', this.roomState);
+    this.broadcast({ type: 'LOG_UPDATE', auditLog: this.roomState.auditLog });
   }
 
 
@@ -194,7 +179,7 @@ export class SigningRoom implements DurableObject {
 
     // 1. Initialize Room
     if (url.pathname === '/init') {
-      const { encryptedPsbt, adminToken, roomId, network, protocolVersion } = await request.json<any>();
+      const { encryptedPsbt, adminToken, roomId, network, protocolVersion, encryptedLogBlob, encryptedRoomName } = await request.json<any>();
       const now = Date.now();
       
       // Default to 24 hour (86400s)
@@ -203,13 +188,17 @@ export class SigningRoom implements DurableObject {
       this.roomState = {
         roomId, encryptedPsbt, adminToken, signatures: [], 
         createdAt: now, expiresAt: now + (ttlSeconds * 1000), 
-        auditLog: [], signerLabels: {}, roomName: "Untitled Room", whitelist: [], 
+        auditLog: [], signerLabels: {}, 
+        whitelist: [], 
         isLocked: false, network: network || 'bitcoin',
-        protocolVersion: protocolVersion || '1.0.0'
+        protocolVersion: protocolVersion || '1.0.0',
+        roomName: encryptedRoomName || "Untitled Room"
       };
 
-      this.roomState.auditLog.push({ timestamp: now, event: 'Room Created', detail: 'Public Session', user: 'System' });
-      
+      if (encryptedLogBlob) {
+          this.roomState.auditLog.push(encryptedLogBlob);
+      }
+
       await this.state.storage.put('data', this.roomState);
       await this.state.storage.setAlarm(now + (ttlSeconds * 1000));
       return new Response('OK');
@@ -274,8 +263,9 @@ export class SigningRoom implements DurableObject {
         msgsInWindow: 0,
         lastMsgTime: 0
     });
+
+    webSocket.send(JSON.stringify({ type: 'SESSION_CONNECTED', sessionId: sessionId }));
     
-    this.log('User Joined', `Session: ${sessionId}`, 'Guest');
     this.broadcast({ type: 'CONNECTIONS_UPDATE', count: this.sessions.size });
     
     // Send initial state sync
@@ -344,8 +334,7 @@ export class SigningRoom implements DurableObject {
             
             await this.state.storage.put('data', this.roomState);
             
-            // Pass the encryptedLogDetail as the 4th parameter!
-            this.log('Label Updated', '', 'Coordinator', msg.encryptedLogDetail);
+            this.log(msg.encryptedLogBlob);
             this.broadcast({ type: 'LABELS_UPDATED', signerLabels: this.roomState.signerLabels });
         }
 
@@ -354,14 +343,13 @@ export class SigningRoom implements DurableObject {
           this.roomState.roomName = msg.encryptedName; 
           await this.state.storage.put('data', this.roomState);
           
-          this.log('Room Renamed', '', 'Coordinator', msg.encryptedLogDetail);
-          
+          this.log(msg.encryptedLogBlob);
           this.broadcast({ type: 'ROOM_RENAMED', encryptedName: msg.encryptedName });
         }
 
         // Action Logging
         if (msg.type === 'LOG_ACTION') {
-          await this.log(msg.action, msg.detail, userLabel);
+          await this.log(msg.encryptedLogBlob);
           this.broadcast({ type: 'LOG_UPDATE', auditLog: this.roomState.auditLog });
         }
 
@@ -376,13 +364,13 @@ export class SigningRoom implements DurableObject {
           this.roomState.signatures.push(msg.data.encryptedData); 
           await this.state.storage.put('data', this.roomState);
           
-          this.log('Signature Uploaded', '', userLabel, msg.encryptedLogDetail);
-          this.broadcast({ type: 'NEW_PARTIAL_DATA', data: msg.data, fingerprint: msg.fingerprint, auditLog: this.roomState.auditLog });
+          this.log(msg.encryptedLogBlob);
+          this.broadcast({ type: 'NEW_PARTIAL_DATA', data: msg.data, fingerprint: msg.fingerprint });
         }
 
         // Destroy Room (Admin Only)
         if (msg.type === 'CLOSE_ROOM' && session?.role === 'admin') {
-          await this.log('Room Destroyed', 'Coordinator closed session', 'Coordinator');
+          await this.log(msg.encryptedLogBlob);
           this.broadcast({ type: 'ROOM_CLOSED', finalLog: this.roomState.auditLog });
           await this.state.storage.deleteAll();
           this.roomState = null;
@@ -394,7 +382,7 @@ export class SigningRoom implements DurableObject {
           this.roomState.whitelist = msg.encryptedWhitelist; 
           await this.state.storage.put('data', this.roomState);
           
-          this.log('Whitelist Updated', '', userLabel, msg.encryptedLogDetail);
+          this.log(msg.encryptedLogBlob);
           this.broadcast({ type: 'WHITELIST_UPDATED', encryptedWhitelist: msg.encryptedWhitelist });
         }
 
@@ -403,8 +391,23 @@ export class SigningRoom implements DurableObject {
         if (msg.type === 'TOGGLE_LOCK' && session?.role === 'admin') {
           this.roomState.isLocked = msg.locked;
           await this.state.storage.put('data', this.roomState);
-          this.log('Security Alert', `Room ${msg.locked ? 'LOCKED' : 'UNLOCKED'}`, 'Coordinator');
+          this.log(msg.encryptedLogBlob);
           this.broadcast({ type: 'LOCK_UPDATED', isLocked: this.roomState.isLocked });
+        }
+
+        // Finalize Transaction (Admin Only)
+        if (msg.type === 'TX_FINALIZED' && session?.role === 'admin') {
+          this.roomState.encryptedFinalTxHex = msg.encryptedFinalTxHex;
+          this.roomState.encryptedFinalTxId = msg.encryptedFinalTxId;
+          await this.state.storage.put('data', this.roomState);
+          
+          this.log(msg.encryptedLogBlob);
+          
+          this.broadcast({ 
+              type: 'TX_FINALIZED_BROADCAST', 
+              encryptedFinalTxHex: msg.encryptedFinalTxHex,
+              encryptedFinalTxId: msg.encryptedFinalTxId
+          });
         }
 
       } catch (e) { console.error(e); }
@@ -414,7 +417,6 @@ export class SigningRoom implements DurableObject {
       const session = this.sessions.get(webSocket);
       this.sessions.delete(webSocket);
       this.broadcast({ type: 'CONNECTIONS_UPDATE', count: this.sessions.size });
-      if (this.roomState) this.log('User Left', `Session ID: ${session?.id}`, 'Guest');
     });
   }
 
@@ -447,12 +449,4 @@ export class SigningRoom implements DurableObject {
         socket.close(1000, "Expired");
     }
   }
-}
-
-function sanitizeInput(input: string, maxLength: number = 120): string {
-    if (typeof input !== 'string') return '';
-    return input
-        .replace(/[<>'"&]/g, '')
-        .trim()
-        .substring(0, maxLength);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signing-room/source",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "license": "AGPL-3.0",
   "author": {
     "name": "Stateless Research Ltd",


### PR DESCRIPTION
## Overview
This PR finalizes the transition to a strict Zero-Knowledge (ZK) architecture for the SigningRoom relay server. The server is now completely blind to sensitive room metadata, audit logs, and finalized settlement data. It acts purely as a secure, stateless message broker and encrypted-blob storage layer.

## Key Changes

### Security & Privacy (Zero-Knowledge)
* **Encrypted Room Names:** The `roomName` is now AES-GCM encrypted upon creation and during rename events. The server only sees and stores an opaque blob.
* **Encrypted Final TX Broadcasts:** The Coordinator now encrypts the finalized TXID and Hex before broadcasting it to Guests, preventing the relay server from inspecting the final settlement.
* **Client-Side Audit Logging:** Moved all audit log generation to the client. The server now only stores and relays opaque encrypted blobs (`encryptedLogBlob`).

### 🐛 Bug Fixes & UI Sync
* **Chronological Log Sorting:** Fixed the `decryptAuditLog` function to properly sort events chronologically (oldest-to-newest) for both the UI and the PDF export.
* **Guest View Restrictions:** Hid the "Broadcast" and "Copy Hex" buttons from Guests when a transaction is finalized. Guests now see a read-only success state.
* **Deterministic Connection Logging:** Refactored `STATE_SYNC` and `ROLE_UPDATE` WebSocket handlers to accurately log Coordinators vs. Guests without race conditions or timeouts.

### Backward Compatibility
* **Graceful Legacy Fallbacks:** Added a fast-fail validation check (`length >= 40` characters) before attempting AES-GCM decryption. This allows the client to seamlessly load older rooms with plaintext names (e.g., "Untitled Room") and plaintext labels without throwing `OperationError` exceptions in the console.

## Impact
* **Cloudflare Workers (`index.ts`):** Now heavily stripped down. Expects only encrypted blobs for logs, names, and final tx data. Max log limit increased to 2,000 to support enterprise/whale PSBTs.
* **Client (`socket.service.ts`):** Takes on full responsibility for state reconstruction, log string generation, and encryption/decryption of all metadata.