### PR TITLE
V1.6.1 - Fix "Session Display issue"

### DIFF
--- a/apps/client/src/app/pages/room/room.component.ts
+++ b/apps/client/src/app/pages/room/room.component.ts
@@ -1391,6 +1391,7 @@ export class RoomComponent implements OnInit, OnDestroy {
     savePersonalName() {
         const name = this.personalDisplayName().trim();
         this.socket.setDisplayName(name);
+        const sid = this.socket.currentSessionId(); 
         const actionLabel = name ? `Identified as "${name}"` : 'Cleared display name';
         this.socket.logAction('Participant Identified', actionLabel);
         this.showSessionsModal.set(false);

--- a/apps/client/src/app/services/socket/socket.service.ts
+++ b/apps/client/src/app/services/socket/socket.service.ts
@@ -277,7 +277,7 @@ export class SocketService {
 
       const encryptedData = await this.encryption.encrypt(payloadToSend, this.encryptionKey);
       
-      const role = this.isCoordinator() ? 'Coordinator' : `Guest (${this.currentSessionId || 'Unknown'})`;
+      const role = this.isCoordinator() ? 'Coordinator' : `Guest (${this.currentSessionId() || 'Unknown'})`;
       const encryptedLogBlob = await this.createSecureLogBlob(
           'Signature Uploaded',
           `Signer: ${detectedFingerprint || 'Unknown'}`,
@@ -305,7 +305,7 @@ export class SocketService {
       const encryptedLogBlob = await this.createSecureLogBlob(
           action, 
           detail, 
-          this.isCoordinator() ? 'Coordinator' : `Guest (${this.currentSessionId || 'Unknown'})`
+          this.isCoordinator() ? 'Coordinator' : `Guest (${this.currentSessionId() || 'Unknown'})`
       );
       
       this.send('LOG_ACTION', { encryptedLogBlob });
@@ -689,7 +689,7 @@ async updateSignerLabel(fingerprint: string, label: string) {
         
                     if (!this.hasAnnouncedJoin && msg.role === 'admin') {
                         this.hasAnnouncedJoin = true;
-                        this.createSecureLogBlob('User Joined', `Session: ${this.currentSessionId}`, 'Coordinator')
+                        this.createSecureLogBlob('User Joined', `Session: ${this.currentSessionId()}`, 'Coordinator')
                             .then(blob => this.send('LOG_ACTION', { encryptedLogBlob: blob }));
                     }
                 }
@@ -854,7 +854,7 @@ async updateSignerLabel(fingerprint: string, label: string) {
 
     if (!this.hasAnnouncedJoin && this.currentSessionId && !hasAdminToken) {
         this.hasAnnouncedJoin = true;
-        this.createSecureLogBlob('User Joined', `Session: ${this.currentSessionId}`, 'Guest')
+        this.createSecureLogBlob('User Joined', `Session: ${this.currentSessionId()}`, 'Guest')
             .then(blob => this.send('LOG_ACTION', { encryptedLogBlob: blob }));
     }
 
@@ -1103,7 +1103,7 @@ async updateSignerLabel(fingerprint: string, label: string) {
           try {
               const encryptedLogBlob = await this.createSecureLogBlob(
                   'User Left', 
-                  `Session ID: ${this.currentSessionId}`, 
+                  `Session ID: ${this.currentSessionId()}`, 
                   'Guest'
               );
               this.send('LOG_ACTION', { encryptedLogBlob });

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -103,7 +103,7 @@ app.use('/*', async (c, next) => {
 app.get('/api/health', (c) => {
   return c.json({ 
     status: 'healthy', 
-    version: '1.6.0', 
+    version: '1.6.1', 
     timestamp: Date.now() 
   });
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signing-room/source",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "AGPL-3.0",
   "author": {
     "name": "Stateless Research Ltd",


### PR DESCRIPTION
Fix for Production "Session Display issue"
We identified an issue where production minification caused Signal function references (e.g., ()=>iu(t)) to cause display issue in audit log

Fixed: All internal logging methods have been updated to explicitly execute Signal getters.

Result: Production Audit Logs will now correctly display 4-character Session IDs (e.g., WH1G) across all event types.