### PR TITLE
feat(opsec): split-key sharing workflows, secure QR codes, and branch coverage

### DIFF
--- a/apps/client/src/app/pages/room/room.component.spec.ts
+++ b/apps/client/src/app/pages/room/room.component.spec.ts
@@ -312,6 +312,7 @@ it('should reject file over 2MB', async () => {
     await component.openQr();
     expect(component.showQrModal()).toBe(true);
     expect(component.isQrRevealed()).toBe(false);
+    expect(component.qrIncludesKey()).toBe(false); // New OpSec default
 
     component.toggleQrReveal();
     expect(component.isQrRevealed()).toBe(true);
@@ -321,24 +322,26 @@ it('should reject file over 2MB', async () => {
     expect(component.showQrModal()).toBe(false);
   });
 
+  it('should toggle QR key inclusion securely', async () => {
+    await component.openQr();
+    component.toggleQrReveal(); // Reveal it
+    expect(component.isQrRevealed()).toBe(true);
+
+    // Toggle to include key
+    await component.toggleQrKey(true);
+    
+    // Should update state and instantly re-blur the image
+    expect(component.qrIncludesKey()).toBe(true);
+    expect(component.isQrRevealed()).toBe(false); 
+  });
+
   it('should handle QR code generation failure gracefully', async () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    
     const QRCode = await import('qrcode');
     vi.spyOn(QRCode, 'toDataURL').mockRejectedValueOnce(new Error('QR Engine Fail'));
 
     await component.openQr();
-    
     expect(consoleSpy).toHaveBeenCalledWith('QR Generation failed', expect.any(Error));
-  });
-
-  it('should copy admin token if it exists in session storage', () => {
-    const clipboardSpy = vi.spyOn(navigator.clipboard, 'writeText');
-    sessionStorage.setItem('admin_token_123', 'admin-secret');
-    
-    component.copyAdminToken();
-    
-    expect(clipboardSpy).toHaveBeenCalledWith('admin-secret');
   });
 
   // ====================== WHITELIST ======================
@@ -440,38 +443,73 @@ it('should reject file over 2MB', async () => {
   });
 
   // ====================== SHARING & UTILS ======================
-  it('should copy invite link and key', () => {
+  it('should handle Share Link modal and secure copying', () => {
     const clipboardSpy = vi.spyOn(navigator.clipboard, 'writeText');
+    const closeSpy = vi.spyOn(component, 'closeShareModal');
+    socketSpy.getRoomKey.mockReturnValue('secret-key');
 
-    component.copyInvite();
-    expect(clipboardSpy).toHaveBeenCalledWith(expect.stringContaining('#key'));
+    component.openShareModal();
+    expect(component.showShareModal()).toBe(true);
+
+    // Test Secure Link
+    component.copySecureLink();
+    expect(clipboardSpy).toHaveBeenCalled();
+    expect(closeSpy).toHaveBeenCalled();
+
+    // Test Full Link
+    component.copyFullLink();
+    expect(clipboardSpy).toHaveBeenCalledWith(expect.stringContaining('#secret-key'));
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('should handle Key modal and copying', () => {
+    const clipboardSpy = vi.spyOn(navigator.clipboard, 'writeText');
+    const closeSpy = vi.spyOn(component, 'closeKeyModal');
+    socketSpy.getRoomKey.mockReturnValue('room-key-123');
+
+    component.openKeyModal();
+    expect(component.showKeyModal()).toBe(true);
 
     component.copyKey();
-    expect(clipboardSpy).toHaveBeenCalledWith('key');
+    expect(clipboardSpy).toHaveBeenCalledWith('room-key-123');
+    expect(closeSpy).toHaveBeenCalled();
+  });
+
+  it('should handle Admin modal and copying', () => {
+    const clipboardSpy = vi.spyOn(navigator.clipboard, 'writeText');
+    const closeSpy = vi.spyOn(component, 'closeAdminModal');
+    sessionStorage.setItem('admin_token_123', 'admin-secret');
+
+    component.openAdminModal();
+    expect(component.showAdminModal()).toBe(true);
+
+    component.copyAdminToken();
+    expect(clipboardSpy).toHaveBeenCalledWith('admin-secret');
+    expect(closeSpy).toHaveBeenCalled();
   });
 
   it('should handle downloadUnsignedPsbt', () => {
-  const anchor = document.createElement('a');
-  const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => {});
-  
-  const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValueOnce(anchor);
-  
-  if (!URL.createObjectURL) URL.createObjectURL = vi.fn();
-  if (!URL.revokeObjectURL) URL.revokeObjectURL = vi.fn();
-  const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const anchor = document.createElement('a');
+    const clickSpy = vi.spyOn(anchor, 'click').mockImplementation(() => {});
+    
+    const createElementSpy = vi.spyOn(document, 'createElement').mockReturnValueOnce(anchor);
+    
+    if (!URL.createObjectURL) URL.createObjectURL = vi.fn();
+    if (!URL.revokeObjectURL) URL.revokeObjectURL = vi.fn();
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
 
-  component.downloadUnsignedPsbt();
-  
-  expect(createElementSpy).toHaveBeenCalledWith('a');
-  expect(clickSpy).toHaveBeenCalled(); // Verify the download was triggered
-  expect(revokeSpy).toHaveBeenCalled();
-});
+    component.downloadUnsignedPsbt();
+    
+    expect(createElementSpy).toHaveBeenCalledWith('a');
+    expect(clickSpy).toHaveBeenCalled();
+    expect(revokeSpy).toHaveBeenCalled();
+  });
 
   it('should handle nudgeSigner', async () => {
     const alertSpy = vi.spyOn(component, 'openAlert' as any);
     component.nudgeSigner('fingerprint123');
     
-    await Promise.resolve(); // Wait for the clipboard promise to resolve
+    await Promise.resolve(); // Wait for clipboard promise
     
     expect(alertSpy).toHaveBeenCalledWith('Nudge Message Copied', expect.any(String));
     expect(socketSpy.logAction).toHaveBeenCalledWith('Nudge Sent', expect.any(String));
@@ -580,5 +618,100 @@ it('should reject file over 2MB', async () => {
     const disconnectSpy = vi.spyOn(socketSpy, 'gracefullyDisconnect');
     component.onBeforeUnload();
     expect(disconnectSpy).toHaveBeenCalled();
+  });
+
+  // ====================== EDGE CASES & EARLY RETURNS ======================
+  
+  it('should abort onFileSelected if no file is provided', async () => {
+    const alertSpy = vi.spyOn(component, 'openAlert' as any);
+    await component.onFileSelected({ target: { files: [] } } as any);
+    // Should return silently without alerting or attempting to parse
+    expect(alertSpy).not.toHaveBeenCalled(); 
+  });
+
+  it('should not rename room if new name is empty or only whitespace', () => {
+    component.newRoomName.set('   ');
+    component.saveRoomName();
+    expect(socketSpy.renameRoom).not.toHaveBeenCalled();
+  });
+
+  it('should abort downloadQr if qrDataUrl is null', () => {
+    component.qrDataUrl.set(null);
+    const createElementSpy = vi.spyOn(document, 'createElement');
+    component.downloadQr();
+    expect(createElementSpy).not.toHaveBeenCalled();
+  });
+
+  it('should abort finalize if the room is expired', () => {
+    component.isExpired.set(true);
+    component.finalize();
+    expect(socketSpy.broadcastFinalization).not.toHaveBeenCalled();
+  });
+
+  it('should not set returnValue on beforeunload if transaction is already finalized', () => {
+    socketSpy.roomState.mockReturnValue({ ...baseRoomState, finalTxHex: 'hex123' });
+    const event = { returnValue: '' } as any;
+    component.unloadNotification(event);
+    // Because finalHex exists, it should NOT set returnValue to true
+    expect(event.returnValue).toBe('');
+  });
+
+  // ====================== URL PARSING & DECRYPTION ======================
+  
+  it('should set decryption error if URL lacks a fragment key on init', () => {
+    (component as any).route.snapshot.fragment = null;
+    component.ngOnInit();
+    
+    expect(socketSpy.decryptionError()).toBe('Missing decryption key in URL');
+  });
+
+  it('should extract key correctly if manualKey contains a full URL with #', () => {
+    component.manualKey = 'https://signingroom.io/room/123#my-secret-key';
+    component.submitKey();
+    expect(socketSpy.connect).toHaveBeenCalledWith('123', 'my-secret-key');
+  });
+
+  it('should abort submitKey if manualKey is empty', () => {
+    component.manualKey = '';
+    component.submitKey();
+    expect(socketSpy.connect).not.toHaveBeenCalled();
+  });
+
+  // ====================== EMPTY ARRAYS & BATCH ACTIONS ======================
+  
+  it('should abort batch verify actions if arrays are empty', () => {
+    socketSpy.txDetails.mockReturnValue({ inputsList: [], outputs: [] });
+    
+    component.verifyAllInputs();
+    expect(socketSpy.updateWhitelistBatch).not.toHaveBeenCalled();
+
+    component.verifyAllOutputs();
+    expect(component.showConfirmModal()).toBe(false); // Shouldn't even open the confirm modal
+  });
+
+  it('should not update whitelist batch if all addresses are already whitelisted', () => {
+    socketSpy.roomState.mockReturnValue({ ...baseRoomState, whitelist: ['addr1', 'addr2'] });
+    socketSpy.txDetails.mockReturnValue({
+      inputsList: [{ address: 'addr1' }],
+      outputs: [{ address: 'addr2' }]
+    });
+
+    component.verifyAllInputs();
+    expect(socketSpy.updateWhitelistBatch).not.toHaveBeenCalled();
+  });
+
+  it('should handle empty arrays in generateAuditLog gracefully', () => {
+    socketSpy.roomState.mockReturnValue({ 
+      ...baseRoomState, 
+      auditLog: [], 
+      participants: {},
+      whitelist: []
+    });
+    socketSpy.txDetails.mockReturnValue({ inputsList: [], outputs: [] });
+    
+    component.generateAuditLog();
+    
+    // As long as jsPDF is called and doesn't crash, the empty branches were handled successfully
+    expect(jsPDF).toHaveBeenCalled(); 
   });
 });

--- a/apps/client/src/app/pages/room/room.component.ts
+++ b/apps/client/src/app/pages/room/room.component.ts
@@ -213,13 +213,40 @@ import * as QRCode from 'qrcode';
 
             <div class="p-6 flex flex-col items-center">
                 
-                <div class="w-full bg-red-500/10 border border-red-500/20 rounded-lg p-3 mb-6 flex items-start gap-3">
-                    <lucide-icon [img]="AlertTriangle" class="w-5 h-5 text-red-400 shrink-0"></lucide-icon>
-                    <p class="text-xs text-red-200 leading-relaxed">
-                        <strong>Security Warning:</strong> This QR code contains the <strong>Private Encryption Key</strong>. 
-                        Anyone who scans this can join the room and view transaction details. Treat it like a password.
-                    </p>
+                <div class="w-full flex bg-slate-950 p-1 rounded-lg border border-slate-800 mb-4">
+                    <button (click)="toggleQrKey(false)" 
+                            class="flex-1 py-1.5 text-xs font-bold rounded-md transition-all flex items-center justify-center gap-2"
+                            [class.bg-slate-800]="!qrIncludesKey()"
+                            [class.text-emerald-400]="!qrIncludesKey()"
+                            [class.text-slate-500]="qrIncludesKey()">
+                        <lucide-icon [img]="Shield" class="w-3 h-3"></lucide-icon>
+                        Link Only
+                    </button>
+                    <button (click)="toggleQrKey(true)" 
+                            class="flex-1 py-1.5 text-xs font-bold rounded-md transition-all flex items-center justify-center gap-2"
+                            [class.bg-slate-800]="qrIncludesKey()"
+                            [class.text-amber-400]="qrIncludesKey()"
+                            [class.text-slate-500]="!qrIncludesKey()">
+                        <lucide-icon [img]="Key" class="w-3 h-3"></lucide-icon>
+                        Full (Link + Key)
+                    </button>
                 </div>
+
+                @if (qrIncludesKey()) {
+                    <div class="w-full bg-amber-500/10 border border-amber-500/20 rounded-lg p-3 mb-6 flex items-start gap-3 animate-in fade-in zoom-in-95 duration-200">
+                        <lucide-icon [img]="AlertTriangle" class="w-5 h-5 text-amber-500 shrink-0"></lucide-icon>
+                        <p class="text-xs text-amber-200/80 leading-relaxed">
+                            <strong>Contains Decryption Key:</strong> Anyone who scans this can join the room and view data. Treat it like a password.
+                        </p>
+                    </div>
+                } @else {
+                    <div class="w-full bg-emerald-500/10 border border-emerald-500/20 rounded-lg p-3 mb-6 flex items-start gap-3 animate-in fade-in zoom-in-95 duration-200">
+                        <lucide-icon [img]="Shield" class="w-5 h-5 text-emerald-400 shrink-0"></lucide-icon>
+                        <p class="text-xs text-emerald-200/80 leading-relaxed">
+                            <strong>Maximum Security:</strong> Key is excluded. You must send the <em>Link Key</em> via a separate secure channel.
+                        </p>
+                    </div>
+                }
 
                 <div class="relative group cursor-pointer" (click)="toggleQrReveal()">
                     
@@ -261,6 +288,125 @@ import * as QRCode from 'qrcode';
                 </button>
             </div>
 
+        </div>
+    </div>
+  }
+
+  @if (showShareModal()) {
+    <div class="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 animate-in fade-in duration-200">
+        <div class="bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden relative">
+
+            <div class="p-4 border-b border-slate-800 flex items-center justify-between">
+                <div class="flex items-center gap-2">
+                    <lucide-icon [img]="Copy" class="w-5 h-5 text-slate-300"></lucide-icon>
+                    <h3 class="font-bold text-white">Share Room Securely</h3>
+                </div>
+                <button (click)="closeShareModal()" class="text-slate-400 hover:text-white transition">
+                    <lucide-icon [img]="X" class="w-5 h-5"></lucide-icon>
+                </button>
+            </div>
+
+            <div class="p-6 flex flex-col gap-4">
+                
+                <div class="border border-emerald-500/30 bg-emerald-950/10 rounded-xl p-4 relative overflow-hidden group">
+                    <div class="flex justify-between items-start mb-2 relative z-10">
+                        <div>
+                            <div class="flex items-center gap-2">
+                                <lucide-icon [img]="Shield" class="w-4 h-4 text-emerald-400"></lucide-icon>
+                                <h4 class="text-white font-bold text-sm">Maximum Security (Split)</h4>
+                            </div>
+                            <p class="text-xs text-slate-400 mt-1 leading-relaxed">
+                                Copies the room URL <strong>without</strong> the decryption key. Send this link, then use the <em>"Link Key"</em> action to send the key via a separate, secure channel (e.g., Signal vs Email).
+                            </p>
+                        </div>
+                    </div>
+                    <button (click)="copySecureLink()" class="mt-3 w-full py-2.5 bg-emerald-500/20 hover:bg-emerald-500/30 text-emerald-400 text-xs font-bold rounded-lg border border-emerald-500/20 transition flex items-center justify-center gap-2 relative z-10">
+                        <lucide-icon [img]="secureLinkCopied() ? Check : Copy" class="w-4 h-4"></lucide-icon>
+                        {{ secureLinkCopied() ? 'Secure Link Copied!' : 'Copy Link Only (No Key)' }}
+                    </button>
+                </div>
+
+                <div class="border border-slate-700 bg-slate-900/50 rounded-xl p-4">
+                    <div class="flex justify-between items-start mb-2">
+                        <div>
+                            <div class="flex items-center gap-2">
+                                <lucide-icon [img]="AlertTriangle" class="w-4 h-4 text-amber-500"></lucide-icon>
+                                <h4 class="text-white font-bold text-sm">Standard (Combined)</h4>
+                            </div>
+                            <p class="text-xs text-slate-400 mt-1 leading-relaxed">
+                                Copies the full URL including the decryption key (<code>#key</code>). Convenient for quick sharing, but if this single link is intercepted, the room is compromised.
+                            </p>
+                        </div>
+                    </div>
+                    <button (click)="copyFullLink()" class="mt-3 w-full py-2.5 bg-slate-800 hover:bg-slate-700 text-white text-xs font-bold rounded-lg border border-slate-700 transition flex items-center justify-center gap-2">
+                        <lucide-icon [img]="fullLinkCopied() ? Check : Copy" class="w-4 h-4"></lucide-icon>
+                        {{ fullLinkCopied() ? 'Full Link Copied!' : 'Copy Full Link (Link + Key)' }}
+                    </button>
+                </div>
+
+            </div>
+        </div>
+    </div>
+  }
+
+  @if (showKeyModal()) {
+    <div class="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 animate-in fade-in duration-200">
+        <div class="bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden relative">
+            <div class="p-4 border-b border-slate-800 flex items-center justify-between">
+                <div class="flex items-center gap-2">
+                    <lucide-icon [img]="Key" class="w-5 h-5 text-cyan-400"></lucide-icon>
+                    <h3 class="font-bold text-white">Room Decryption Key</h3>
+                </div>
+                <button (click)="closeKeyModal()" class="text-slate-400 hover:text-white transition">
+                    <lucide-icon [img]="X" class="w-5 h-5"></lucide-icon>
+                </button>
+            </div>
+            <div class="p-6 flex flex-col gap-4">
+                <div class="w-full bg-cyan-500/10 border border-cyan-500/20 rounded-lg p-3 flex items-start gap-3">
+                    <lucide-icon [img]="AlertTriangle" class="w-5 h-5 text-cyan-400 shrink-0"></lucide-icon>
+                    <p class="text-xs text-cyan-200 leading-relaxed">
+                        <strong>Sensitive Data:</strong> This is the private encryption key for the room. Anyone with this key can decrypt and view the transaction details if they also have the room link.
+                    </p>
+                </div>
+                <p class="text-xs text-slate-400 leading-relaxed">
+                    For maximum operational security, send this key to signers using a different communication channel than the one used for the room link (e.g., Signal vs. Email).
+                </p>
+                <button (click)="copyKey()" class="mt-2 w-full py-2.5 bg-cyan-500/20 hover:bg-cyan-500/30 text-cyan-400 text-xs font-bold rounded-lg border border-cyan-500/20 transition flex items-center justify-center gap-2">
+                    <lucide-icon [img]="keyCopied() ? Check : Copy" class="w-4 h-4"></lucide-icon>
+                    {{ keyCopied() ? 'Key Copied!' : 'Copy Decryption Key' }}
+                </button>
+            </div>
+        </div>
+    </div>
+  }
+
+  @if (showAdminModal()) {
+    <div class="fixed inset-0 z-[100] flex items-center justify-center bg-slate-950/80 backdrop-blur-sm p-4 animate-in fade-in duration-200">
+        <div class="bg-slate-900 border border-slate-700 rounded-2xl shadow-2xl max-w-md w-full overflow-hidden relative">
+            <div class="p-4 border-b border-slate-800 flex items-center justify-between">
+                <div class="flex items-center gap-2">
+                    <lucide-icon [img]="FileKey" class="w-5 h-5 text-purple-400"></lucide-icon>
+                    <h3 class="font-bold text-white">Backup Admin Token</h3>
+                </div>
+                <button (click)="closeAdminModal()" class="text-slate-400 hover:text-white transition">
+                    <lucide-icon [img]="X" class="w-5 h-5"></lucide-icon>
+                </button>
+            </div>
+            <div class="p-6 flex flex-col gap-4">
+                <div class="w-full bg-purple-500/10 border border-purple-500/20 rounded-lg p-3 flex items-start gap-3">
+                    <lucide-icon [img]="AlertOctagon" class="w-5 h-5 text-purple-400 shrink-0"></lucide-icon>
+                    <p class="text-xs text-purple-200 leading-relaxed">
+                        <strong>High Privilege:</strong> This token allows any guest in the room to claim the "Coordinator" role.
+                    </p>
+                </div>
+                <p class="text-xs text-slate-400 leading-relaxed">
+                    Coordinators have the authority to manage whitelists, lock the room, verify inputs, and broadcast the final transaction. Only share this with trusted co-administrators.
+                </p>
+                <button (click)="copyAdminToken()" class="mt-2 w-full py-2.5 bg-purple-500/20 hover:bg-purple-500/30 text-purple-400 text-xs font-bold rounded-lg border border-purple-500/20 transition flex items-center justify-center gap-2">
+                    <lucide-icon [img]="adminCopied() ? Check : Copy" class="w-4 h-4"></lucide-icon>
+                    {{ adminCopied() ? 'Admin Token Copied!' : 'Copy Admin Token' }}
+                </button>
+            </div>
         </div>
     </div>
   }
@@ -414,16 +560,16 @@ import * as QRCode from 'qrcode';
 
                 @if (socket.isCoordinator()) {
                     <div class="relative group">
-                        <button (click)="copyKey()" class="px-3 py-2 text-cyan-400 hover:bg-cyan-950/30 hover:text-cyan-300 rounded-lg transition text-xs font-bold flex items-center gap-2 border border-transparent hover:border-cyan-500/20">
+                        <button (click)="openKeyModal()" class="px-3 py-2 text-cyan-400 hover:bg-cyan-950/30 hover:text-cyan-300 rounded-lg transition text-xs font-bold flex items-center gap-2 border border-transparent hover:border-cyan-500/20">
                             <lucide-icon [img]="keyCopied() ? Check : Key" class="w-4 h-4"></lucide-icon>
-                            {{ keyCopied() ? 'Link Key' : 'Link Key' }}
+                            {{ keyCopied() ? 'Copied' : 'Link Key' }}
                         </button>
                     </div>
 
                     <div class="w-px h-6 bg-slate-800 mx-1"></div>
 
                     <div class="relative group">
-                        <button (click)="copyAdminToken()" class="px-3 py-2 text-purple-400 hover:bg-purple-950/30 hover:text-purple-300 rounded-lg transition text-xs font-bold flex items-center gap-2 border border-transparent hover:border-purple-500/20">
+                        <button (click)="openAdminModal()" class="px-3 py-2 text-purple-400 hover:bg-purple-950/30 hover:text-purple-300 rounded-lg transition text-xs font-bold flex items-center gap-2 border border-transparent hover:border-purple-500/20">
                             <lucide-icon [img]="adminCopied() ? Check : FileKey" class="w-4 h-4"></lucide-icon>
                             {{ adminCopied() ? 'Copied' : 'Backup Admin' }}
                         </button>
@@ -433,9 +579,9 @@ import * as QRCode from 'qrcode';
                 }
 
                 <div class="relative group">
-                    <button (click)="copyInvite()" class="px-3 py-2 text-slate-300 hover:bg-slate-800 hover:text-white rounded-lg transition text-xs font-bold flex items-center gap-2 border border-transparent hover:border-slate-700">
-                        <lucide-icon [img]="inviteCopied() ? Check : Copy" class="w-4 h-4"></lucide-icon>
-                        {{ inviteCopied() ? 'Copied' : 'Share Link' }}
+                    <button (click)="openShareModal()" class="px-3 py-2 text-slate-300 hover:bg-slate-800 hover:text-white rounded-lg transition text-xs font-bold flex items-center gap-2 border border-transparent hover:border-slate-700">
+                        <lucide-icon [img]="Copy" class="w-4 h-4"></lucide-icon>
+                        Share Link
                     </button>
                 </div>
 
@@ -1004,10 +1150,13 @@ export class RoomComponent implements OnInit, OnDestroy {
 
     public showQrModal = signal(false);
     public showSessionsModal = signal(false);
+    public showKeyModal = signal(false);
+    public showAdminModal = signal(false);
     public personalDisplayName = signal('');
     public copiedSessionId = signal<string | null>(null);
     public isQrRevealed = signal(false);
     public qrDataUrl = signal<string | null>(null);
+    public qrIncludesKey = signal(false);
     
     public timeRemaining = signal("Loading...");
     public isExpired = signal(false);
@@ -1052,7 +1201,9 @@ export class RoomComponent implements OnInit, OnDestroy {
     // -------------------------------------------------------------------------
     public finalHex = computed(() => this.socket.roomState()?.finalTxHex || null);
     public copied = signal(false);
-    public inviteCopied = signal(false);
+    public showShareModal = signal(false);
+    public secureLinkCopied = signal(false);
+    public fullLinkCopied = signal(false);
     public keyCopied = signal(false);
     public adminCopied = signal(false);
     
@@ -1533,11 +1684,23 @@ export class RoomComponent implements OnInit, OnDestroy {
 
     async openQr() {
         this.showQrModal.set(true);
-        this.isQrRevealed.set(false); // Always reset to hidden for security
-        
-        // Generate the QR code on the fly
+        this.isQrRevealed.set(false); 
+        this.qrIncludesKey.set(false); 
+        await this.generateQrData();
+    }
+
+    async toggleQrKey(includesKey: boolean) {
+        this.qrIncludesKey.set(includesKey);
+        this.isQrRevealed.set(false);
+        await this.generateQrData();
+    }
+
+    private async generateQrData() {
         try {
-            const link = this.getFullShareLink();
+            const link = this.qrIncludesKey() 
+                ? this.getFullShareLink() 
+                : window.location.href.split('#')[0];
+
             const dataUrl = await QRCode.toDataURL(link, {
                 width: 400,
                 margin: 2,
@@ -1545,7 +1708,7 @@ export class RoomComponent implements OnInit, OnDestroy {
                     dark: '#000000',
                     light: '#ffffff'
                 },
-                errorCorrectionLevel: 'M' // Medium is good balance for scanning vs density
+                errorCorrectionLevel: 'M'
             });
             this.qrDataUrl.set(dataUrl);
         } catch (err) {
@@ -2043,11 +2206,6 @@ export class RoomComponent implements OnInit, OnDestroy {
 
     copyHex() { this.doCopy(this.finalHex() || '', this.copied); }
 
-    copyAdminToken() { 
-        const t = sessionStorage.getItem(`admin_token_${this.roomId()}`);
-        if(t) this.doCopy(t, this.adminCopied);
-    }
-
     private doCopy(text: string, signalToToggle: any) {
         navigator.clipboard.writeText(text);
         if (signalToToggle) {
@@ -2062,14 +2220,6 @@ export class RoomComponent implements OnInit, OnDestroy {
         return `${baseUrl}${key ? '#' + key : ''}`;
     }
 
-    copyKey() { 
-        this.doCopy(this.socket.getRoomKey() || '', this.keyCopied); 
-    }
-
-    copyInvite() { 
-        this.doCopy(this.getFullShareLink(), this.inviteCopied); 
-    }
-
     nudgeSigner(fingerprint: string) {
         const label = this.getSignerLabel(fingerprint); 
         const msg = `Signature needed from: ${label}\n${this.getFullShareLink()}`;
@@ -2078,5 +2228,53 @@ export class RoomComponent implements OnInit, OnDestroy {
             this.openAlert('Nudge Message Copied', `Nudge message for ${label} copied! Paste it in your chat app.`);
         });
         this.socket.logAction('Nudge Sent', `Reminder sent to ${label}`);
+    }
+
+    // -------------------------------------------------------------------------
+    // Actions: OpSec Link Sharing
+    // -------------------------------------------------------------------------
+
+    openShareModal() {
+        this.showShareModal.set(true);
+    }
+
+    closeShareModal() {
+        this.showShareModal.set(false);
+    }
+
+    copySecureLink() {
+        // Gets the URL without the #key fragment
+        const baseUrl = window.location.href.split('#')[0];
+        this.doCopy(baseUrl, this.secureLinkCopied);
+        this.closeShareModal();
+    }
+
+    copyFullLink() {
+        // Gets the URL including the #key fragment
+        this.doCopy(this.getFullShareLink(), this.fullLinkCopied);
+        this.closeShareModal();
+    }
+
+    // -------------------------------------------------------------------------
+    // Actions: OpSec Key & Admin Sharing
+    // -------------------------------------------------------------------------
+
+    openKeyModal() { this.showKeyModal.set(true); }
+    closeKeyModal() { this.showKeyModal.set(false); }
+
+    openAdminModal() { this.showAdminModal.set(true); }
+    closeAdminModal() { this.showAdminModal.set(false); }
+
+    // Update your existing copyKey method
+    copyKey() { 
+        this.doCopy(this.socket.getRoomKey() || '', this.keyCopied); 
+        this.closeKeyModal();
+    }
+
+    // Update your existing copyAdminToken method
+    copyAdminToken() { 
+        const t = sessionStorage.getItem(`admin_token_${this.roomId()}`);
+        if(t) this.doCopy(t, this.adminCopied);
+        this.closeAdminModal();
     }
 }

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -103,7 +103,7 @@ app.use('/*', async (c, next) => {
 app.get('/api/health', (c) => {
   return c.json({ 
     status: 'healthy', 
-    version: '1.7.0', 
+    version: '1.8.0', 
     timestamp: Date.now() 
   });
 });


### PR DESCRIPTION
**Description:**
This release hardens the Operational Security (OpSec) of the Signing Room platform at the human layer. By introducing strategic friction before sensitive actions, we ensure that the "Zero Knowledge" architecture is actively enforced by the Coordinator, preventing accidental leakage of decryption keys.

**OpSec Enhancements:**

Secure Link Sharing: Replaced the 1-click "Share Link" button with an interactive modal. Users must now explicitly choose between "Maximum Security" (copies the room URL without the decryption fragment) and "Standard" (full link).

Secure-by-Default QR Codes: The QR Code generator now defaults to "Link Only" (No Key). The image actively re-blurs if the user toggles to the less secure "Full Link" option, preventing shoulder-surfing.

Privilege Friction: Added clear, color-coded warning modals when a Coordinator copies the Room Decryption Key (Cyan) or the Backup Admin Token (Purple), explaining the specific risks of each asset and suggesting out-of-band communication (e.g., Signal).

**UI & UX Improvements:**

Icon Consistency: Updated UI icons within modals to match their trigger buttons (e.g., matching clipboard/copy icons) for a tighter, more intuitive mental model.

**Testing & Coverage:**

Fixed Broken Tests: Updated the test suite to accommodate the refactored copySecureLink and copyFullLink methods.

Massive Branch Coverage Boost: Added extensive test blocks targeting component edge cases, early returns, malformed URLs, and empty data arrays. This significantly boosts the room.component.ts branch coverage.

**Room Decryption Key Modal**
<img width="674" height="491" alt="image" src="https://github.com/user-attachments/assets/2b9dd5cb-6576-46f7-8851-9ce50fea7572" />

**Backup Admin Token Modal**
<img width="674" height="461" alt="image" src="https://github.com/user-attachments/assets/61100781-9417-48f0-bc61-9195223a97b0" />

**Share Room Securely Modal**
<img width="674" height="681" alt="image" src="https://github.com/user-attachments/assets/e5bcd549-cfac-45d4-a40e-f1fbe35b3c03" />

**Room QR Code Modal - Link only**
<img width="578" height="893" alt="image" src="https://github.com/user-attachments/assets/97948271-f612-4830-b823-be62a2a74269" />

**Room QR Code Modal - Full Link + Key**
<img width="578" height="921" alt="image" src="https://github.com/user-attachments/assets/e3c87a92-d8e9-4183-99c0-1fc33edbed0d" />

